### PR TITLE
Remove colons in merge message example in contributing doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,11 @@ Finally, a longer description should be added that details the change.
     <Uneditable line re: which branch and pull request are getting merged>
     <Editable second line>
     
-    Reviewer: <names>
-    Fixes: #<issue number>
+    Reviewers <names>
+    Fixes #<issue number>
 
     Long description (as long as you wish)
 
+["Fixes #issue" will close one or more issues](https://help.github.com/articles/closing-issues-via-commit-messages).  Note the lack of colon after the word "Fixes" - if a colon appears after "Fixes", the issue will not be automatically closed.
 
 Once the pull request is merged, if using branches, please delete the branch.


### PR DESCRIPTION
Merging #6 did not close #5, because if there is a colon between 'fixes' and the issue number, github fails to interpret this as a directive to close the issue.

So I modified the contributing doc so the example doesn't have a colon either, and point this lack of colon out as well.  Since the colon was removed from 'Fixes', I also removed the colon after "Reviewers" because that looks strange.
