### PR TITLE
depend on recent version of Twisted, tls extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
     url="https://github.com/twisted/vertex",
     scripts=["bin/gvertex", "bin/vertex"],
     install_requires=[
-        'Twisted>=13.1.0',
-        'pyOpenSSL>=0.13',
+        'Twisted[tls]>=16.6.0',
         'automat',
         'pretend',
     ],


### PR DESCRIPTION
Depending on just pyOpenSSL, we get the version warning from Twisted about service_identity.