### PR TITLE
Txscrypt password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install codecov
   - pip install pretend
   - pip install git+https://github.com/twisted/twistedchecker@9cec9f5b40d1b5cb4d6dcda26ec0ba6e05de4b62#egg=twistedchecker
-  - pip install .
+  - pip install -e .
 
 matrix:
   include:

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,12 @@ setup(
     url="https://github.com/twisted/vertex",
     scripts=["bin/gvertex", "bin/vertex"],
     install_requires=[
+        'attrs',
         'Twisted>=13.1.0',
         'pyOpenSSL>=0.13',
         'automat',
         'pretend',
+        'txscrypt',
     ],
     license="MIT",
     platforms=["any"],

--- a/vertex/ivertex.py
+++ b/vertex/ivertex.py
@@ -33,14 +33,37 @@ class IQ2QUserStore(Interface):
     """
     A store of L{IQ2QUser} providers.
     """
-    def store(self, domain, username, password):
+
+    def store(domain, username, password):
         """
-        Store a username and password for a domain.
+        Store a password for a user.
+
+        @param domain: The domain where this username is exists.
+        @type domain: L{str}
+
+        @param username: The user's name.
+        @type username: L{str}
+
+        @param password: The user's password.
+        @type password: L{str}
+
+        @return: A L{defer.Deferred} that fires when the key derived from
+            C{password} as been associated with this user and domain.
+        @rtype: L{defer.Deferred}
         """
 
-    def check(self, domain, username, password):
+    def key(domain, username):
         """
-        Check
+        Retrieve the key derived from a user's password.
+
+        @param domain: The domain where this username is exists.
+        @type domain: L{str}
+
+        @param username: The user's name.
+        @type username: L{str}
+
+        @return: The derived key for this user.
+        @rtype: L{str}
         """
 
 

--- a/vertex/ivertex.py
+++ b/vertex/ivertex.py
@@ -29,6 +29,8 @@ class IQ2QUser(Interface):
         certificateRequest are valid.
         """
 
+
+
 class IQ2QUserStore(Interface):
     """
     A store of L{IQ2QUser} providers.

--- a/vertex/ivertex.py
+++ b/vertex/ivertex.py
@@ -29,6 +29,21 @@ class IQ2QUser(Interface):
         certificateRequest are valid.
         """
 
+class IQ2QUserStore(Interface):
+    """
+    A store of L{IQ2QUser} providers.
+    """
+    def store(self, domain, username, password):
+        """
+        Store a username and password for a domain.
+        """
+
+    def check(self, domain, username, password):
+        """
+        Check
+        """
+
+
 class IFileTransfer(Interface):
 
     def getUploadSink(self, path):

--- a/vertex/q2q.py
+++ b/vertex/q2q.py
@@ -2163,12 +2163,8 @@ class Q2QService(service.MultiService, protocol.ServerFactory):
             cert = signResponse['certificate']
             privcert = certpair(cert, kp)
             apc(str(fromAddress), privcert)
-        gettingSecureConnection.addCallback(gotSignResponse)
-
-        return self.getSecureConnection(
-            fromAddress, fromAddress.domainAddress(), authorize=False,
-            usePrivateCertificate=fakecert,
-        ).addCallback(gotSecureConnection)
+            return signResponse
+        return gettingSecureConnection.addCallback(gotSignResponse)
 
 
     def authorize(self, fromAddress, password):

--- a/vertex/q2q.py
+++ b/vertex/q2q.py
@@ -52,7 +52,7 @@ from vertex.command import (
     )
 from vertex.conncache import ConnectionCache
 
-# extra
+# Extra
 import attr
 import txscrypt
 
@@ -114,8 +114,8 @@ class UsernameShadowPassword(object):
             L{self.password} matches the key and L{False} when not.
         @rtype: L{Deferred}
         """
-        # password is actually the derived key we stored, while
-        # self.password is the plain-text password.
+        # The password parameter is actually the derived key we
+        # stored, while self.password is the plain-text password.
         return self._keyDeriver.checkPassword(password, self.password)
 
 
@@ -1778,6 +1778,8 @@ class DefaultCertificateStore:
 
     def requestAvatarId(self, credentials):
         """
+        Return the ID associated with these credentials.
+
         @param credentials: something which implements one of the interfaces in
         self.credentialInterfaces.
 

--- a/vertex/q2q.py
+++ b/vertex/q2q.py
@@ -1682,8 +1682,10 @@ class _InMemoryUserStore(object):
 
     def store(self, domain, username, password):
         cryptDeferred = self._crypt.computeKey(password)
-        cryptDeferred.addCallback(self._keys.__setitem__,
-                                  (domain, username))
+        def _cbStoreKey(key):
+            self._keys[(domain, username)] = key
+
+        cryptDeferred.addCallback(_cbStoreKey)
         return cryptDeferred
 
     def key(self, domain, username):

--- a/vertex/q2qstandalone.py
+++ b/vertex/q2qstandalone.py
@@ -6,7 +6,9 @@ import os
 
 from twisted.cred.portal import Portal
 
+from twisted.internet import defer
 from twisted.protocols.amp import AMP, Box, parseString
+from twisted.python.filepath import FilePath
 
 from vertex import q2q
 from vertex.ivertex import IQ2QUserStore

--- a/vertex/q2qstandalone.py
+++ b/vertex/q2qstandalone.py
@@ -68,6 +68,24 @@ class _UserStore(object):
 
 
     def store(self, domain, username, password):
+        """
+        Store a key derived from this password, for this user, in this
+        domain.
+
+        @param domain: The domain for this user.
+        @type domain: L{str}
+
+        @param username: The name of this user.
+        @type username: L{str}
+
+        @param password: This user's password.
+        @type password: L{str}
+
+        @return: A L{defer.Deferred} that fires with the domain,
+            username pair if this user has never been seen before, and
+            L{NotAllowed} if it has.
+        @rtype: L{defer.Deferred}
+        """
         domainpath = self.path.child(domain)
         domainpath.makedirs(ignoreExistingDirectory=True)
         userpath = domainpath.child(username + ".info")
@@ -86,6 +104,19 @@ class _UserStore(object):
 
 
     def key(self, domain, username):
+        """
+        Retrieve the derived key for user with this name, in this
+        domain.
+
+        @param domain: This user's domain.
+        @type domain: L{str}
+
+        @param username: This user's name.
+        @type username: L{str}
+
+        @return: The user's key if they exist; otherwise L{None}.
+        @rtype: L{str} or L{None}
+        """
         userpath = self.path.child(domain).child(username + ".info")
         if userpath.exists():
             with userpath.open() as f:

--- a/vertex/test/_fakes.py
+++ b/vertex/test/_fakes.py
@@ -1,8 +1,9 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
 """
 Verified fakes used across tests.
 """
 from pretend import stub, call, call_recorder
-from twisted.cred.credentials import UsernamePassword
 from twisted.internet import defer
 from twisted.trial import unittest
 import txscrypt
@@ -18,10 +19,14 @@ def _makeStubTxscrypt(computeKeyReturns, checkPasswordReturns):
     @param computeKeyReturns: What C{computeKey} should return.
 
     @param checkPasswordReturns: What C{checkPassword} should return.
+
+    @return: A L{stub} implementation of L{txscrypt}
+    @rtype: L{stub}
     """
 
     def computeKey(password):
         return computeKeyReturns
+
 
     def checkPassword(key, password):
         return checkPasswordReturns
@@ -42,6 +47,10 @@ def _makeStubCredentials(username, password, checkPasswordReturns):
     @type password: L{str}
 
     @param checkPasswordReturns: What C{checkPassword} should return.
+
+    @return: A L{stub} implementation of
+        L{twisted.python.cred.credentials.UsernamePassword}
+    @rtype: L{stub}
     """
 
     def checkPassword(password):
@@ -55,14 +64,20 @@ def _makeStubCredentials(username, password, checkPasswordReturns):
 
 def _makeStubIQ2QUserStore(storeReturns, keyReturns):
     """
-    Construct a stub L{IQ2QUserStore} implementer.
+    Construct a stub L{vertex.ivertex.IQ2QUserStore} implementer.
 
     @param storeReturns: What C{store} returns.
+
     @param keyReturns: What C{key} returns.
+
+    @return: A L{stub} implementation of
+        L{vertex.ivertex.IQ2QUserStore}
+    @rtype: L{stub}
     """
 
     def store(domain, username, password):
         return storeReturns
+
 
     def key(domain, username):
         return keyReturns
@@ -77,8 +92,10 @@ class VerifyStubTxscrypt(unittest.TestCase):
     same as L{txscrypt}.
     """
 
-
     def setUp(self):
+        """
+        Setup the test.
+        """
         self.computeKeyReturns = defer.Deferred()
         self.checkPasswordReturns = defer.Deferred()
 

--- a/vertex/test/_fakes.py
+++ b/vertex/test/_fakes.py
@@ -1,0 +1,158 @@
+"""
+Verified fakes used across tests.
+"""
+from pretend import stub, call, call_recorder
+from twisted.cred.credentials import UsernamePassword
+from twisted.internet import defer
+from twisted.trial import unittest
+import txscrypt
+
+from zope.interface.declarations import directlyProvides
+
+
+
+def _makeStubTxscrypt(computeKeyReturns, checkPasswordReturns):
+    """
+    Construct a stub L{txscrypt} implementation.
+
+    @param computeKeyReturns: What C{computeKey} should return.
+
+    @param checkPasswordReturns: What C{checkPassword} should return.
+    """
+
+    def computeKey(password):
+        return computeKeyReturns
+
+    def checkPassword(key, password):
+        return checkPasswordReturns
+
+    return stub(computeKey=call_recorder(computeKey),
+                checkPassword=call_recorder(checkPassword))
+
+
+
+def _makeStubCredentials(username, password, checkPasswordReturns):
+    """
+    Construct a stub L{IUsernamePassword} implementer.
+
+    @param username: The username.
+    @type username: L{str}
+
+    @param password: The password.
+    @type password: L{str}
+
+    @param checkPasswordReturns: What C{checkPassword} should return.
+    """
+
+    def checkPassword(password):
+        return checkPasswordReturns
+
+    return stub(username=username,
+                password=password,
+                checkPassword=call_recorder(checkPassword))
+
+
+
+def _makeStubIQ2QUserStore(storeReturns, keyReturns):
+    """
+    Construct a stub L{IQ2QUserStore} implementer.
+
+    @param storeReturns: What C{store} returns.
+    @param keyReturns: What C{key} returns.
+    """
+
+    def store(domain, username, password):
+        return storeReturns
+
+    def key(domain, username):
+        return keyReturns
+
+    return stub(store=call_recorder(store), key=call_recorder(key))
+
+
+
+class VerifyStubTxscrypt(unittest.TestCase):
+    """
+    Test that the stub returned by L{_makeStubTxscrypt} behaves the
+    same as L{txscrypt}.
+    """
+
+
+    def setUp(self):
+        self.computeKeyReturns = defer.Deferred()
+        self.checkPasswordReturns = defer.Deferred()
+
+        self.fakeTxscrypt = _makeStubTxscrypt(
+            computeKeyReturns=self.computeKeyReturns,
+            checkPasswordReturns=self.checkPasswordReturns,
+        )
+
+
+    @defer.inlineCallbacks
+    def test_computeKey(self):
+        """
+        The stub key computer accepts the same arguments as the real
+        key computer, both return a L{defer.Deferred} that fires with
+        the computed key.
+        """
+        password = "password"
+        realKey = yield txscrypt.computeKey(password)
+
+        self.computeKeyReturns.callback(realKey)
+        fakeKey = yield self.fakeTxscrypt.computeKey(password)
+
+        self.assertEqual(realKey, fakeKey)
+        self.assertEqual(self.fakeTxscrypt.computeKey.calls, [call(password)])
+
+
+    @defer.inlineCallbacks
+    def compareCheckPassword(self, keyPassword, password):
+        """
+        Assert that L{txscrypt.checkPassword} and the stub
+        C{checkPassword} agree that C{password} matches or does not
+        match the key derived from C{keyPassword}.
+
+        @param keyPassword: The password from which to derive a key.
+        @type keyPassword: L{str}
+
+        @param password: The password to check against the derived
+            key.
+        @type password: L{str}
+
+        @return: A L{defer.Deferred} that fires when the results have
+            been compared.
+        @rtype: L{defer.Deferred}
+        """
+        key = yield txscrypt.computeKey(keyPassword)
+
+        realResult = yield txscrypt.checkPassword(key, password)
+
+        self.checkPasswordReturns.callback(realResult)
+        fakeResult = yield self.fakeTxscrypt.checkPassword(key, password)
+
+        self.assertEqual(realResult, fakeResult)
+        self.assertEqual(
+            self.fakeTxscrypt.checkPassword.calls,
+            [call(key, password)],
+        )
+
+
+    def test_checkPasswordMatches(self):
+        """
+        The stub password checker accepts the same arguments as the
+        real password checker, and both return a L{defer.Deferred} that
+        fires with L{True} when the the password matches the key.
+        """
+        return self.compareCheckPassword(keyPassword="password",
+                                         password="password")
+
+
+    def test_checkPassword_doesNotMatch(self):
+        """
+        The stub password checker accepts the same arguments as the
+        real password checker, and both return a L{defer.Deferred} that
+        fires with L{False} when the the password does not match the
+        key.
+        """
+        return self.compareCheckPassword(keyPassword="password",
+                                         password="wrong password")

--- a/vertex/test/test_q2q.py
+++ b/vertex/test/test_q2q.py
@@ -411,13 +411,18 @@ class ConnectionTestMixin:
                           privateSecret, serverService,
                           serverDomain):
         svc = self._makeQ2QService(username + '@' + serverDomain, None)
-        serverService.certificateStorage.addUser(serverDomain,
-                                                 username,
-                                                 privateSecret)
         svc.setServiceParent(self.msvc)
-        return svc.authorize(q2q.Q2QAddress(serverDomain, username),
-                             privateSecret).addCallback(lambda x: svc)
 
+        added = serverService.certificateStorage.addUser(serverDomain,
+                                                         username,
+                                                         privateSecret)
+
+        def _cbAuthorize(_):
+            return svc.authorize(q2q.Q2QAddress(serverDomain, username),
+                                 privateSecret).addCallback(lambda x: svc)
+
+        added.addCallback(_cbAuthorize)
+        return added
 
     def testListening(self):
         _1 = self.addClientService(self.toAddress, 'aaaa', self.serverService)

--- a/vertex/test/test_q2q.py
+++ b/vertex/test/test_q2q.py
@@ -676,6 +676,7 @@ class TCPConnection(Q2QConnectionTestCase, ConnectionTestMixin):
     udpEnabled = False
     virtualEnabled = False
 
+
 # class LiveServerMixin:
 #     serverDomain = 'test.domain.example.com'
 

--- a/vertex/test/test_q2q.py
+++ b/vertex/test/test_q2q.py
@@ -4,11 +4,13 @@
 """
 Tests for L{vertex.q2q}.
 """
+from pretend import call
 
 from cStringIO import StringIO
 
 from twisted.trial import unittest
 from twisted.application import service
+from twisted.cred.error import UnauthorizedLogin
 from twisted.internet import reactor, protocol, defer
 from twisted.internet.task import deferLater
 from twisted.internet.ssl import DistinguishedName, PrivateCertificate, KeyPair
@@ -19,11 +21,19 @@ from twisted.internet.error import ConnectionDone
 # from twisted.internet.main import CONNECTION_DONE
 
 from zope.interface import implements
+from zope.interface.verify import verifyObject
 from twisted.internet.interfaces import IResolverSimple
 
 from twisted.protocols.amp import UnknownRemoteError, QuitBox, Command, AMP
 
+import txscrypt
+
+from ._fakes import (_makeStubTxscrypt,
+                     _makeStubCredentials,
+                     _makeStubIQ2QUserStore)
+
 from vertex import q2q
+from vertex import ivertex
 
 
 def noResources(*a):
@@ -654,6 +664,74 @@ class ConnectionTestMixin:
         return d
 
 
+class DefaultCertificateStoreTestCase(unittest.SynchronousTestCase):
+    """
+    Tests for L{q2q.DefaultCertificateStore}.
+    """
+
+    def setUp(self):
+        self.store = q2q.DefaultCertificateStore()
+        self.username="username@domain"
+
+        self.checkPasswordReturns = defer.Deferred()
+        self.credentials = _makeStubCredentials(
+            username=self.username,
+            password="password",
+            checkPasswordReturns=self.checkPasswordReturns,
+        )
+
+
+    def test_requestAvatarIdUnknownUser(self):
+        """
+        A L{Deferred} failed with L{UnauthorizedLogin} is returned
+        when an unknown user is requested.
+        """
+        self.store.users = _makeStubIQ2QUserStore(
+            keyReturns=None,
+            storeReturns=defer.Deferred(),
+        )
+
+        failure = self.failureResultOf(
+            self.store.requestAvatarId(self.credentials),
+        )
+        self.assertIsInstance(failure.value, UnauthorizedLogin)
+
+
+    def test_requestAvatarIdWrongPassword(self):
+        """
+        A L{Deferred} that fires with with L{UnauthorizedLogin} is returned
+        when the wrong password is provided.
+        """
+        self.store.users = _makeStubIQ2QUserStore(
+            keyReturns="key",
+            storeReturns=defer.Deferred(),
+        )
+
+        wrongPasswordDeferred = self.store.requestAvatarId(self.credentials)
+
+        self.assertNoResult(wrongPasswordDeferred)
+        self.checkPasswordReturns.callback(False)
+        failure = self.failureResultOf(wrongPasswordDeferred)
+        self.assertIsInstance(failure.value, UnauthorizedLogin)
+
+
+    def test_requestAvatarId(self):
+        """
+        A L{Deferred} that fires with with the username is returned
+        when the the right password is provided.
+        """
+        self.store.users = _makeStubIQ2QUserStore(
+            keyReturns="key",
+            storeReturns=defer.Deferred(),
+        )
+
+        wrongPasswordDeferred = self.store.requestAvatarId(self.credentials)
+
+        self.assertNoResult(wrongPasswordDeferred)
+        self.checkPasswordReturns.callback(True)
+        self.assertEqual(self.successResultOf(wrongPasswordDeferred),
+                         self.username)
+
 
 
 class VirtualConnection(Q2QConnectionTestCase, ConnectionTestMixin):
@@ -680,6 +758,107 @@ class TCPConnection(Q2QConnectionTestCase, ConnectionTestMixin):
     inboundTCPPortnum = 0
     udpEnabled = False
     virtualEnabled = False
+
+
+
+class UsernameShadowPasswordTestCase(unittest.SynchronousTestCase):
+    """
+    Tests for L{q2q.UsernameShadowPassword}.
+    """
+
+    def setUp(self):
+        self.username = "username"
+        self.password = "password"
+
+        self.checkPasswordReturns = defer.Deferred()
+
+        self.fakeTxscrypt = _makeStubTxscrypt(
+            computeKeyReturns=defer.Deferred(),
+            checkPasswordReturns=self.checkPasswordReturns,
+        )
+
+        self.credentials = q2q.UsernameShadowPassword(
+            username=self.username,
+            password=self.password,
+            keyDeriver=self.fakeTxscrypt,
+        )
+
+
+    def test_checkPassword(self):
+        """
+        The provided key is checked against the credentials'
+        plain-text password, and the result returned
+        """
+        key = "key"
+        result = self.credentials.checkPassword(key)
+        self.assertEqual(
+            self.fakeTxscrypt.checkPassword.calls,
+            [call(key, self.password)],
+        )
+        self.assertIs(result, self.checkPasswordReturns)
+
+
+    def test_txscryptIsdefaultKeyDeriver(self):
+        """
+        L{txscrypt} is the default key deriver.
+        """
+        credentials = q2q.UsernameShadowPassword(
+            username=self.username,
+            password=self.password,
+        )
+        self.assertIs(credentials._keyDeriver, txscrypt)
+
+
+
+class InMemoryUserStoreTestCase(unittest.SynchronousTestCase):
+    """
+    Tests for L{q2q._InMemoryUserStore}
+    """
+
+    def setUp(self):
+        self.computeKeyReturns = defer.Deferred()
+
+        self.fakeTxscrypt = _makeStubTxscrypt(
+            computeKeyReturns=self.computeKeyReturns,
+            checkPasswordReturns=defer.Deferred(),
+        )
+
+        self.users = q2q._InMemoryUserStore(
+            keyDeriver=self.fakeTxscrypt,
+        )
+
+
+    def test_providesIQ2QUserStore(self):
+        """
+        The store provides L{ivertex.IQ2QUserStore}
+        """
+        verifyObject(ivertex.IQ2QUserStore, self.users)
+
+
+    def test_storeAndRetrieveKey(self):
+        """
+        A key is derived for a password and stored under the domain
+        and user.
+        """
+        domain, username, password, key = "domain", "user", "password", "key"
+
+        storedDeferred = self.users.store(domain, username, password)
+
+        self.assertNoResult(storedDeferred)
+        self.computeKeyReturns.callback(key)
+        self.assertEqual(self.successResultOf(storedDeferred),
+                         (domain, username))
+
+        self.assertEqual(self.users.key(domain, username), key)
+
+
+    def test_missingKey(self):
+        """
+        The derived key for an unknown domain and user combination is
+        L{None}.
+        """
+        self.assertIsNone(self.users.key("mystery domain", "mystery user"))
+
 
 
 # class LiveServerMixin:

--- a/vertex/test/test_q2q.py
+++ b/vertex/test/test_q2q.py
@@ -664,14 +664,15 @@ class ConnectionTestMixin:
         return d
 
 
-class DefaultCertificateStoreTestCase(unittest.SynchronousTestCase):
+
+class DefaultCertificateStoreTests(unittest.SynchronousTestCase):
     """
     Tests for L{q2q.DefaultCertificateStore}.
     """
 
     def setUp(self):
         self.store = q2q.DefaultCertificateStore()
-        self.username="username@domain"
+        self.username = "username@domain"
 
         self.checkPasswordReturns = defer.Deferred()
         self.credentials = _makeStubCredentials(
@@ -761,7 +762,7 @@ class TCPConnection(Q2QConnectionTestCase, ConnectionTestMixin):
 
 
 
-class UsernameShadowPasswordTestCase(unittest.SynchronousTestCase):
+class UsernameShadowPasswordTests(unittest.SynchronousTestCase):
     """
     Tests for L{q2q.UsernameShadowPassword}.
     """
@@ -810,7 +811,7 @@ class UsernameShadowPasswordTestCase(unittest.SynchronousTestCase):
 
 
 
-class InMemoryUserStoreTestCase(unittest.SynchronousTestCase):
+class InMemoryUserStoreTests(unittest.SynchronousTestCase):
     """
     Tests for L{q2q._InMemoryUserStore}
     """

--- a/vertex/test/test_standalone.py
+++ b/vertex/test/test_standalone.py
@@ -7,13 +7,20 @@ Tests for L{vertex.q2qstandalone}
 from pretend import call_recorder, call, stub
 
 from twisted.internet import defer
+from twisted.python.filepath import FilePath
 from twisted.protocols.amp import AMP
 from twisted.test.iosim import connect, makeFakeClient, makeFakeServer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import TestCase, SynchronousTestCase
 
 from vertex.q2q import Q2QAddress
-from vertex.q2qadmin import AddUser
+from vertex.q2qadmin import AddUser, NotAllowed
 from vertex.q2qstandalone import IdentityAdmin
+from vertex.q2qstandalone import _UserStore
+from vertex import ivertex
+
+from zope.interface.verify import verifyObject
+
+from ._fakes import _makeStubTxscrypt
 
 
 class AddUserAdminTests(TestCase):
@@ -60,3 +67,100 @@ class AddUserAdminTests(TestCase):
 
         # the server responds with {}
         self.assertEqual({}, self.successResultOf(d))
+
+
+
+class UserStoreTestCase(SynchronousTestCase):
+    """
+    Tests for L{_UserStore}
+    """
+
+    def setUp(self):
+        self.userPath = FilePath(self.mktemp())
+        self.userPath.makedirs()
+        self.addCleanup(self.userPath.remove)
+        self.makeUsers(self.userPath.path)
+
+
+    def makeUsers(self, path):
+        """
+        Create a L{_UserStore} instance pointed at C{path}.
+
+        @param path: The path where the instance will store its
+            per-user files.
+        @type path: L{str}
+        """
+
+        self.computeKeyReturns = defer.Deferred()
+
+        self.fakeTxscrypt = _makeStubTxscrypt(
+            computeKeyReturns=self.computeKeyReturns,
+            checkPasswordReturns=defer.Deferred(),
+        )
+
+        self.users = _UserStore(
+            path=path,
+            keyDeriver=self.fakeTxscrypt,
+        )
+
+
+    def test_providesIQ2QUserStore(self):
+        """
+        The store provides L{ivertex.IQ2QUserStore}
+        """
+        verifyObject(ivertex.IQ2QUserStore, self.users)
+
+
+    def assertStored(self, domain, username, password, key):
+        """
+        Assert that C{password} is stored under C{user} and C{domain}.
+
+        @param domain: The user's 'domain.
+        @type domain: L{str}
+
+        @param username: The username.
+        @type username: L{str}
+
+        @param key: The key "derived" from C{password}
+        @type key: L{str}
+        """
+        storedDeferred = self.users.store(domain, username, password)
+
+        self.assertNoResult(storedDeferred)
+        self.computeKeyReturns.callback(key)
+        self.assertEqual(self.successResultOf(storedDeferred),
+                         (domain, username))
+
+    def test_storeAndRetrieveKey(self):
+        """
+        A key is derived for a password and stored under the domain
+        and user.
+        """
+        domain, username, password, key = "domain", "user", "password", "key"
+
+        self.assertStored(domain, username, password, key)
+        self.assertEqual(self.users.key(domain, username), key)
+
+    def test_missingKey(self):
+        """
+        The derived key for an unknown domain and user combination is
+        L{None}.
+        """
+        self.assertIsNone(self.users.key("mystery domain", "mystery user"))
+
+
+    def test_storeExistingUser(self):
+        """
+        Attempting to overwrite an existing user fails with
+        L{NotAllowed}
+        """
+        domain, username, password, key = "domain", "user", "password", "key"
+
+        self.assertStored(domain, username, password, key)
+
+        self.makeUsers(self.userPath.path)
+
+        failure = self.failureResultOf(self.users.store(domain,
+                                                        username,
+                                                        password))
+        self.assertIsInstance(failure.value, NotAllowed)

--- a/vertex/test/test_standalone.py
+++ b/vertex/test/test_standalone.py
@@ -70,7 +70,7 @@ class AddUserAdminTests(TestCase):
 
 
 
-class UserStoreTestCase(SynchronousTestCase):
+class UserStoreTests(SynchronousTestCase):
     """
     Tests for L{_UserStore}
     """
@@ -121,6 +121,9 @@ class UserStoreTestCase(SynchronousTestCase):
         @param username: The username.
         @type username: L{str}
 
+        @param password: The password.
+        @type password: L{str}
+
         @param key: The key "derived" from C{password}
         @type key: L{str}
         """
@@ -131,6 +134,7 @@ class UserStoreTestCase(SynchronousTestCase):
         self.assertEqual(self.successResultOf(storedDeferred),
                          (domain, username))
 
+
     def test_storeAndRetrieveKey(self):
         """
         A key is derived for a password and stored under the domain
@@ -140,6 +144,7 @@ class UserStoreTestCase(SynchronousTestCase):
 
         self.assertStored(domain, username, password, key)
         self.assertEqual(self.users.key(domain, username), key)
+
 
     def test_missingKey(self):
         """

--- a/vertex/test/test_standalone.py
+++ b/vertex/test/test_standalone.py
@@ -6,6 +6,7 @@ Tests for L{vertex.q2qstandalone}
 
 from pretend import call_recorder, call, stub
 
+from twisted.internet import defer
 from twisted.protocols.amp import AMP
 from twisted.test.iosim import connect, makeFakeClient, makeFakeServer
 from twisted.trial.unittest import TestCase
@@ -20,7 +21,9 @@ class AddUserAdminTests(TestCase):
     Tests that IdentityAdmin can successfully add a user
     """
     def setUp(self):
-        self.addUser = call_recorder(lambda *args, **kwargs: {})
+        self.addUser = call_recorder(
+            lambda *args, **kwargs: defer.succeed("ignored")
+        )
         store = stub(addUser=self.addUser)
         self.adminFactory = stub(store=store)
 


### PR DESCRIPTION
Closes #34.

`txscrypt` runs scrypt in a thread, so the dictionary-like user storage mechanism won't do.  This PR introduces a new interface to replace it: `IQ2QUserStore`.  Its `store` method returns a `Deferred` that fires only when the key has been computed.
 
Verification happens through `UserShadowPassword`, a new `IUsernamePassword` implementer whose `checkPassword` calls out to `txscrypt`.  Unfortunately the logic is backwards because `checkPassword` is called with the stored key derived by `txscrypt.computeKey`.

[A bug in `Q2QService.requestCertificateForAddress` has been fixed](https://github.com/twisted/vertex/commit/2aee9f32b663d0ba8f18e49a967501e024f1dfa9).

I wrote some standardized fakes using `pretend` which is not my preference.  I didn't want to add yet another testing strategy in this commit, though.